### PR TITLE
Updated time_dead tooltip

### DIFF
--- a/json/tooltips.json
+++ b/json/tooltips.json
@@ -72,7 +72,7 @@
   "first_blood_time": "The time first blood occurred",
   "kda": "(Kills+Assists)/(Deaths+1)",
   "stuns": "Seconds of disable on heroes",
-  "time_dead": "Seconds dead",
+  "time_dead": "Time dead",
   "tower_kills": "Number of towers killed",
   "neutral_kills": "Number of neutral creeps killed",
   "courier_kills": "Number of couriers killed",


### PR DESCRIPTION
time_dead reports in minutes:seconds, not seconds. Updated tag to response to [YASP issue 1143](https://github.com/yasp-dota/yasp/issues/1143)